### PR TITLE
update dependancies to support laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": ">=5.4",
+        "laravel/framework": ">=9.*",
         "goez/drafter-php": "^7.0.1",
         "hmaus/reynaldo": "^0.1.5",
         "erusev/parsedown": "^1.7.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "m165437/laravel-blueprint-docs",
+    "name": "hschub/laravel-blueprint-docs",
     "description": "API Blueprint Renderer for Laravel",
     "keywords": [
         "api",
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "laravel/framework": ">=5.4|~7.0",
-        "hmaus/drafter-php": "^6.1.1",
+        "laravel/framework": ">=5.4",
+        "goez/drafter-php": "^7.0.1",
         "hmaus/reynaldo": "^0.1.5",
         "erusev/parsedown": "^1.7.0",
         "erusev/parsedown-extra": "^0.7.1"

--- a/src/BlueprintDocs.php
+++ b/src/BlueprintDocs.php
@@ -2,7 +2,7 @@
 
 namespace M165437\BlueprintDocs;
 
-use Hmaus\DrafterPhp\Drafter;
+use Goez\DrafterPhp\Drafter;
 use Hmaus\Reynaldo\Parser\RefractParser;
 use M165437\BlueprintDocs\Elements\Api;
 

--- a/src/BlueprintDocsServiceProvider.php
+++ b/src/BlueprintDocsServiceProvider.php
@@ -3,7 +3,7 @@
 namespace M165437\BlueprintDocs;
 
 use Illuminate\Support\ServiceProvider;
-use Hmaus\DrafterPhp\Drafter;
+use Goez\DrafterPhp\Drafter;
 
 class BlueprintDocsServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
We have to fork the repository because it's not only the `M165437/laravel-blueprint-docs` should have updated dependencies, but also a sub-required `drafter-php` needs its update.

 - Remove laravel version constraint
 - Use drifter package that supports symfony/process ^6.0
 - Use correct namespace